### PR TITLE
Add zone substitutions to the shared-storage example

### DIFF
--- a/shared-storage/infra/cloudbuild.yaml
+++ b/shared-storage/infra/cloudbuild.yaml
@@ -16,6 +16,7 @@ timeout: 3600s
 substitutions:
   _ACTION: apply
   _NAME: broker
+  _ZONE: us-west1-a
 
 steps:
   ###
@@ -27,5 +28,7 @@ steps:
     env:
       - TF_VAR_project_id=${PROJECT_ID}
       - TF_VAR_name=${_NAME}
+      - TF_VAR_zone=${_ZONE}
       - TERRAFORM_WORKSPACE_NAME=broker-filestore
       - ACTION=${_ACTION}
+      


### PR DESCRIPTION
Changes:
- Add zone substitution to the shared-storage example to be able to reference the example terraform module and deploy the Filestore instance to a custom zone.