### PR TITLE
Update nfs-client-provisioner image

### DIFF
--- a/shared-storage/manifests/nfs-client.yaml
+++ b/shared-storage/manifests/nfs-client.yaml
@@ -95,7 +95,7 @@ spec:
       serviceAccountName: nfs-client-provisioner
       containers:
         - name: nfs-client-provisioner
-          image: quay.io/external_storage/nfs-client-provisioner:latest
+          image: gcr.io/k8s-staging-sig-storage/nfs-subdir-external-provisioner:v4.0.2
           volumeMounts:
             - name: nfs-client-root
               mountPath: /persistentvolumes


### PR DESCRIPTION
Changes
- Update `nfs-client-provisioner` image to use the one recommended in the provisioner [repo](https://github.com/kubernetes-sigs/nfs-subdir-external-provisioner)

Note: the [current image](https://quay.io/repository/external_storage/nfs-client-provisioner?tag=latest&tab=tags) hasn't been updated for the last 3 years.