### PR TITLE
[code-server] Fix code-server-cloudshell image building

### DIFF
--- a/code-server/images/code-server-cloudshell/Dockerfile
+++ b/code-server/images/code-server-cloudshell/Dockerfile
@@ -40,7 +40,7 @@ RUN curl -o ffmpeg-xpra.deb -L https://www.xpra.org/dists/stretch/main/binary-am
 # Install xpra, xephyr and xfce4
 RUN curl -sfL https://xpra.org/repos/buster/xpra.list | tee /etc/apt/sources.list.d/xpra-beta.list && \
 	curl -sfL https://xpra.org/gpg.asc | apt-key add - && \
-    apt-get update && DEBIAN_FRONTEND=noninteractive apt-get install -y \
+    apt-get update --allow-releaseinfo-change && DEBIAN_FRONTEND=noninteractive apt-get install -y \
         xpra \
         xterm \
         xfce4 \


### PR DESCRIPTION
Steps to reproduce the problem

1- Clone source code 

```
git clone https://github.com/selkies-project/selkies-examples.git && cd
```

2- Build the images using Cloud Build
```
(cd selkies-examples/code-server/images/ && gcloud builds submit)
```

Error log
```
Step #1 - "code-server-cloudshell": E: Repository 'https://packages.sury.org/php buster InRelease' changed its 'Suite' value from '' to 'buster'
Step #1 - "code-server-cloudshell": The command '/bin/sh -c curl -sfL https://xpra.org/repos/buster/xpra.list | tee /etc/apt/sources.list.d/xpra-beta.list && 	curl -sfL https://xpra.org/gpg.asc | apt-key add - &&     apt-get update && DEBIAN_FRONTEND=noninteractive apt-get install -y         xpra         xterm         xfce4         xfce4-terminal' returned a non-zero code: 100
Finished Step #1 - "code-server-cloudshell"
ERROR
ERROR: build step 1 "gcr.io/cloud-builders/docker" failed: step exited with non-zero status: 100
Step #1 - "code-server-cloudshell": 
```