### PR TITLE
Use latest available kubectl in cloud builder image

### DIFF
--- a/external-auth/cloudbuild.yaml
+++ b/external-auth/cloudbuild.yaml
@@ -29,7 +29,7 @@ steps:
     args:
       - "-exc"
       - |
-        kubectl.1.17 kustomize manifests/ | \
+        kubectl kustomize manifests/ | \
           sed 's/$${PROJECT_ID}/'${PROJECT_ID}'/g' | \
           /builder/kubectl.bash apply -f -
         

--- a/node-init-image-cache/cloudbuild-install-cronjob.yaml
+++ b/node-init-image-cache/cloudbuild-install-cronjob.yaml
@@ -71,7 +71,7 @@ steps:
         export CLOUDSDK_COMPUTE_REGION="$${cluster_toks[1]}"
         export CLOUDSDK_CONTAINER_CLUSTER="$${cluster_toks[0]}"
 
-        kubectl.1.17 kustomize cache-update-cronjob | \
+        kubectl kustomize cache-update-cronjob | \
           sed -e 's/$${PROJECT_ID}/${PROJECT_ID}/g' \
               -e 's/$${_PROVISION_MACHINE_TYPE}/${_PROVISION_MACHINE_TYPE}/g' \
               -e 's/$${_IMAGE_BUILD_REGION}/${_IMAGE_BUILD_REGION}/g' \

--- a/node-init-image-cache/manifests/deploy_manifests.sh
+++ b/node-init-image-cache/manifests/deploy_manifests.sh
@@ -48,7 +48,7 @@ kubectl delete cronjob -n pod-broker-system ${DISK_ZONE}-image-puller-subscripti
 
 sed -i -e 's/${ZONE}/'${DISK_ZONE}'/g' kustomization.yaml
 
-kubectl.1.17 kustomize | \
+kubectl kustomize | \
   sed \
     -e 's/${PROJECT_ID}/'${PROJECT_ID}'/g' \
     -e 's/${PD_NAME}/'${PD_NAME}'/g' \


### PR DESCRIPTION
Attempts to execute `kubectl.1.17` failed with the error message 

```log
bash: kubectl.1.17: command not found
```

Current supported version of `kubectl` in cloud builder `gcr.io/cloud-builders/kubectl`

```
Client Version: version.Info{Major:"1", Minor:"21+", GitVersion:"v1.21.9-dispatcher", GitCommit:"2a8027f41d28b788b001389f3091c245cd0a9a60", GitTreeState:"clean", BuildDate:"2022-01-21T20:26:49Z", GoVersion:"go1.16.12", Compiler:"gc", Platform:"linux/amd64"}
```