### PR TITLE
Fix cloudbuild-install-cronjob.yaml to use the first zone detected in…

### DIFF
--- a/node-init-image-cache/cloudbuild-install-cronjob.yaml
+++ b/node-init-image-cache/cloudbuild-install-cronjob.yaml
@@ -75,7 +75,7 @@ steps:
           sed -e 's/$${PROJECT_ID}/${PROJECT_ID}/g' \
               -e 's/$${_PROVISION_MACHINE_TYPE}/${_PROVISION_MACHINE_TYPE}/g' \
               -e 's/$${_IMAGE_BUILD_REGION}/${_IMAGE_BUILD_REGION}/g' \
-              -e 's/$${_IMAGE_BUILD_ZONE}/$${BUILD_ZONE}/g' \
+              -e 's/$${_IMAGE_BUILD_ZONE}/'$${BUILD_ZONE}'/g' \
               -e 's/$${_EXCLUDE_REGIONS}/${_EXCLUDE_REGIONS}/g' \
               -e 's/$${_DISK_SIZE_GB}/${_DISK_SIZE_GB}/g' \
               -e 's/$${_IMAGE_BUILD_SCHEDULE}/${_IMAGE_BUILD_SCHEDULE}/g' \


### PR DESCRIPTION
Fix `cloudbuild-install-cronjob.yaml` usage of the first zone detected in the zones.txt file. With the previous change, the zone is not substituted and the cache build job fails.

Error log
```
Finished Step #4 - "packer-build"
Step #4 - "packer-build": * a zone must be specified
Step #4 - "packer-build": 
Step #4 - "packer-build": 1 error(s) occurred:
Step #4 - "packer-build": 
```