### PR TITLE
Configure App Launcher Custom Domain

### DIFF
--- a/custom-domain/README.md
+++ b/custom-domain/README.md
@@ -1,0 +1,114 @@
+# Selkies - Configure a Custom Domain
+
+## Overview
+
+The following document describes how to configure a custom domain for the App Launcher of a Selkies Deployment.
+
+## Steps
+
+### Step 1: DNS Configuration
+
+Add a CNAME record to the custom domain on the DNS provider or register, using the Default App Launcher domain as the value for the CNAME.
+
+```markdown
+Default App Launcher domain: broker.endpoints.${PROJECT_ID?}.cloud.goog
+
+Where PROJECT_ID is the GCP Project ID of the created deployment.
+```
+
+| Record type | Host               | Value                                      |
+|-------------|--------------------|--------------------------------------------|
+| CNAME       | custom.example.com | broker.endpoints.${PROJECT_ID?}.cloud.goog |
+
+Allow up to 24 hours for the propagation of the created CNAME record, this process normally takes a few minutes though.
+
+### Step 2: Create/Update the Secret Manager Secrets
+
+#### Automated pipeline to create the secrets
+
+Declare variables needed for the automated pipeline where:
+
+- `_REGION`: cluster region
+- `_CUSTOM_DOMAIN`: this variable is used to especify the custom domain for the App Launcher Portal.
+- `_LB_DOMAINS`: is the list of additional domains to add to the managed certificate and configure in the cluster Load Balancer.
+
+```bash
+export _REGION=REPLACE_WITH_VALID_REGION
+export _CUSTOM_DOMAIN="custom.example.com"
+export _LB_DOMAINS="custom.example.com,another.example.com"
+```
+
+Execute pipeline
+
+```bash
+gcloud builds submit --project ${PROJECT_ID?} --substitutions=^--^_ACTION=apply--_REGION=${_REGION}--_CUSTOM_DOMAIN=${_CUSTOM_DOMAIN}--_LB_DOMAINS=${_LB_DOMAINS}
+```
+
+#### Create secrets manually
+
+##### Update the project load balancer to use the DNS record and provision a Managed SSL Certificate.
+
+Create or update the broker-tfvars-lbdomains secret with the following content:
+additional_ssl_certificate_domains = [
+    "${CUSTOM_DOMAIN}"
+]
+
+From the Selkies core repo, `setup/infra` subdirectory, run cloud build to preview then apply the domain change.
+
+```bash
+cd PATH_TO_YOUR_SELKIES_REPO_DIR
+cd setup/infra
+gcloud builds submit --project ${PROJECT_ID?} --substitutions=_ACTION=plan
+gcloud builds submit --project ${PROJECT_ID?} --substitutions=_ACTION=apply
+```
+
+Allow some time for the SSL certificate to be provisioned, this may take up to 24 hours after the CNAME is pointed to the Default App Launcher domain. In most cases, propagation of the records and provisioning of the SSL certificate will happen within a few hours, depending on the domain provider.
+
+##### Create broker-custom-domain secret
+
+Custom domain secret  broker-custom-domain, this information is pulled during the manifest deployment step to configure the pod-broker with the configured domain.
+
+```bash
+gcloud secrets create  broker-custom-domain --replication-policy=automatic --data-file - <<EOF
+${CUSTOM_DOMAIN}?
+EOF
+```
+
+From the selkies repo, re-deploy the manifests from the selkies repo, `setup/manifests` directory to roll out the custom domain change.
+
+##### Update the broker-logout-url secret
+
+To properly redirect the browser to the correct url, the `secret broker-logout-url` has to be updated with the custom domain.
+
+```bash
+gcloud secrets versions add broker-logout-url --data-file=-
+<<EOF
+"https://${CUSTOM_DOMAIN}?gcp-iap-mode=GCIP_SIGNOUT"
+EOF
+```
+
+### Step 3: Apply infra changes
+
+From the Selkies core repo, `setup/infra` subdirectory, run cloud build to apply the domain change.
+
+```bash
+cd PATH_TO_YOUR_SELKIES_REPO_DIR
+cd setup/infra
+gcloud builds submit --project ${PROJECT_ID?} --substitutions=_ACTION=apply
+```
+
+Allow some time for the SSL certificate to be provisioned, this may take up to 24 hours after the CNAME is pointed to the Default App Launcher domain. In most cases, propagation of the records and provisioning of the SSL certificate will happen within a few hours, depending on the domain provider.
+
+### Step 4: Re-deploy manifests
+
+From the selkies repo, re-deploy the manifests from the selkies repo, `setup/manifests` directory to roll out the previusly configured changes.
+
+```bash
+cd PATH_TO_YOUR_SELKIES_REPO_DIR
+cd setup/manifests
+gcloud builds submit --project ${PROJECT_ID?}
+```
+
+### Step 5: Reinstall PWAs (Optional)
+
+If any PWAs were installed, will need to be re-installed after being launched from the new URL.

--- a/custom-domain/cloudbuild.yaml
+++ b/custom-domain/cloudbuild.yaml
@@ -1,0 +1,33 @@
+timeout: 300s
+substitutions:
+  _ACTION: apply
+  _NAME: broker
+  _REGION:
+  _CUSTOM_DOMAIN: ""
+  _LB_DOMAINS: ""
+tags:
+  - custom-domain
+steps:
+  ###
+  # Cleanup any existing sub-jobs to prevent overlapping executions.
+  ###
+  - name: "gcr.io/cloud-builders/gcloud"
+    id: cleanup-sub-jobs
+    entrypoint: bash
+    args:
+      - -c
+      - |
+        gcloud -q builds list --ongoing --filter='tags[]~custom-domain-infra' --format='value(id)' | \
+          xargs --no-run-if-empty gcloud -q builds cancel >/dev/null
+
+  ###
+  # Provision infrastructure to create secrets
+  ###
+  - name: "gcr.io/cloud-builders/gcloud"
+    id: custom-domain-infra
+    dir: infra
+    entrypoint: "bash"
+    args:
+      - "-exc"
+      - |
+        gcloud builds submit --substitutions=^--^_NAME=${_NAME}--_ACTION=${_ACTION}--_REGION=${_REGION}--_CUSTOM_DOMAIN=${_CUSTOM_DOMAIN}--_LB_DOMAINS=${_LB_DOMAINS}

--- a/custom-domain/infra/cloudbuild.yaml
+++ b/custom-domain/infra/cloudbuild.yaml
@@ -1,0 +1,24 @@
+timeout: 600s
+substitutions:
+  _ACTION: apply
+  _NAME: broker
+  _REGION:
+  _CUSTOM_DOMAIN:
+  _LB_DOMAINS:
+tags:
+  - custom-domain-infra
+steps:
+  ###
+  # Apply terraform to provision infrastructure
+  ###
+  - name: "gcr.io/${PROJECT_ID}/${_NAME}-installer"
+    id: "terraform-apply"
+    entrypoint: "/workspace/deploy.sh"
+    env:
+      - TF_VAR_project_id=${PROJECT_ID}
+      - TF_VAR_name=${_NAME}
+      - TF_VAR_region=${_REGION}
+      - TF_VAR_custom_domain=${_CUSTOM_DOMAIN}
+      - TF_VAR_lb_domains=${_LB_DOMAINS}
+      - TERRAFORM_WORKSPACE_NAME=${_NAME}-${_REGION}-custom-domain
+      - ACTION=${_ACTION}

--- a/custom-domain/infra/deploy.sh
+++ b/custom-domain/infra/deploy.sh
@@ -1,0 +1,60 @@
+#!/bin/bash
+
+set -e
+
+export RED='\033[1;31m'
+export CYAN='\033[1;36m'
+export GREEN='\033[1;32m'
+export NC='\033[0m' # No Color
+function log_red() { echo -e "${RED}$@${NC}"; }
+function log_cyan() { echo -e "${CYAN}$@${NC}"; }
+function log_green() { echo -e "${GREEN}$@${NC}"; }
+
+SCRIPT_DIR=$(dirname $(readlink -f $0 2>/dev/null) 2>/dev/null || echo "${PWD}/$(dirname $0)")
+
+cd "${SCRIPT_DIR}"
+
+# Fetch any Secret Manager secrets named ${TF_VAR_name?}-tfvars* and same them to .auto.tfvars files.
+for secret in $(gcloud -q secrets list --filter=name~${TF_VAR_name?}-tfvars- --format="value(name)"); do
+    latest=$(gcloud secrets versions list ${secret} --sort-by=created --format='value(name)' --limit=1)
+    dest="${secret/${TF_VAR_name?}-tfvars-/}.auto.tfvars"
+    log_cyan "Creating ${dest} from secret: ${secret}"
+    gcloud -q secrets versions access ${latest} --secret ${secret} > ${dest}
+done
+
+# Fetch any Secret Manager secrets named ${TF_VAR_name?}-${TERRAFORM_WORKSPACE_NAME}-tfvars* and same them to .auto.tfvars files.
+for secret in $(gcloud -q secrets list --filter=name~${TF_VAR_name?}-${TERRAFORM_WORKSPACE_NAME}-tfvars- --format="value(name)"); do
+    latest=$(gcloud secrets versions list ${secret} --sort-by=created --format='value(name)' --limit=1)
+    dest="${secret/${TF_VAR_name?}-${TERRAFORM_WORKSPACE_NAME}-tfvars-/}.auto.tfvars"
+    log_cyan "Creating ${dest} from secret: ${secret}"
+    gcloud -q secrets versions access ${latest} --secret ${secret} > ${dest}
+done
+
+export TF_IN_AUTOMATION=1
+
+# Set default project for google provider.
+export GOOGLE_PROJECT=${TF_VAR_project_id?}
+
+# Initialize backend and select workspace
+terraform init -upgrade=true -input=false \
+    -backend-config="bucket=${TF_VAR_project_id?}-${TF_VAR_name?}-tf-state" \
+    -backend-config="prefix=${TF_VAR_name?}" || true
+terraform workspace select ${TERRAFORM_WORKSPACE_NAME?} || terraform workspace new ${TERRAFORM_WORKSPACE_NAME?}
+terraform init -input=false \
+    -backend-config="bucket=${TF_VAR_project_id?}-${TF_VAR_name?}-tf-state" \
+    -backend-config="prefix=${TF_VAR_name?}" || true
+if [[ "${ACTION?}" == "destroy" ]]; then
+    log_cyan "Running terraform destroy..."
+    terraform destroy -auto-approve -input=false
+elif [[ "${ACTION?}" == "plan" ]]; then
+    log_cyan "Running terraform plan..."
+    terraform plan -out terraform.tfplan -input=false
+elif [[ "${ACTION?}" == "apply" ]]; then
+    log_cyan "Running terraform plan..."
+    terraform plan -out terraform.tfplan -input=false
+
+    log_cyan "Running terraform apply..."
+    terraform apply -input=false terraform.tfplan
+fi
+
+log_green "Done"

--- a/custom-domain/infra/main.tf
+++ b/custom-domain/infra/main.tf
@@ -1,0 +1,48 @@
+#broker-custom-domain
+resource "google_secret_manager_secret" "broker_custom_domain_secret_manager_secret" {
+  count     = var.custom_domain == "" ? 0 : 1
+  project   = var.project_id
+  secret_id = "broker-custom-domain"
+
+  replication {
+    automatic = true
+  }
+}
+
+resource "google_secret_manager_secret_version" "broker_custom_domain_secret_manager_version" {
+  count       = var.custom_domain == "" ? 0 : 1
+  secret      = google_secret_manager_secret.broker_custom_domain_secret_manager_secret.0.id
+  secret_data = var.custom_domain
+}
+
+#broker-tfvars-lb-domains
+resource "google_secret_manager_secret" "broker_lb_domains_secret_manager_secret" {
+  count     = var.lb_domains == "" ? 0 : 1
+  project   = var.project_id
+  secret_id = "broker-tfvars-lb-domains"
+
+  replication {
+    automatic = true
+  }
+}
+
+resource "google_secret_manager_secret_version" "broker_lb_domains_secret_manager_version" {
+  count       = var.lb_domains == "" ? 0 : 1
+  secret      = google_secret_manager_secret.broker_lb_domains_secret_manager_secret.0.id
+  secret_data = format("additional_ssl_certificate_domains =%s", jsonencode(toset(split(",", var.lb_domains))))
+}
+
+#broker-logout-url
+resource "google_secret_manager_secret" "broker_logout_url_secret_manager_secret" {
+  project   = var.project_id
+  secret_id = "broker-logout-url"
+
+  replication {
+    automatic = true
+  }
+}
+
+resource "google_secret_manager_secret_version" "broker_logout_url_secret_manager_version" {
+  secret      = google_secret_manager_secret.broker_logout_url_secret_manager_secret.id
+  secret_data = var.custom_domain == "" ? "https://broker.endpoints.${var.project_id}.cloud.goog?gcp-iap-mode=GCIP_SIGNOUT" : "https://${var.custom_domain}?gcp-iap-mode=GCIP_SIGNOUT"
+}

--- a/custom-domain/infra/variables.tf
+++ b/custom-domain/infra/variables.tf
@@ -1,0 +1,25 @@
+variable "project_id" {
+  description = "Project ID"
+  type        = string
+}
+
+variable "name" {
+  default = "broker"
+  type    = string
+}
+
+variable "region" {
+  description = "GCP Region where the cluster is created"
+  type        = string
+}
+
+variable "lb_domains" {
+  description = "List of domains separated by commas, to create managed SSL certificates and configure in the Load Balancer"
+  type        = string
+  default     = null
+}
+variable "custom_domain" {
+  description = "Custom domain for the App Launcher Portal"
+  type        = string
+  default     = null
+}

--- a/custom-domain/infra/versions.tf
+++ b/custom-domain/infra/versions.tf
@@ -1,0 +1,7 @@
+terraform {
+  backend "gcs" {}
+  required_version = ">= 0.12"
+  required_providers {
+    google = "~> 3.57"
+  }
+}


### PR DESCRIPTION
# Selkies - Configure a Custom Domain

## Overview

The following document describes how to configure a custom domain for the App Launcher of a Selkies Deployment.

## Steps

### Step 1: DNS Configuration

Add a CNAME record to the custom domain on the DNS provider or register, using the Default App Launcher domain as the value for the CNAME.

```markdown
Default App Launcher domain: broker.endpoints.${PROJECT_ID?}.cloud.goog

Where PROJECT_ID is the GCP Project ID of the created deployment.
```

| Record type | Host               | Value                                      |
|-------------|--------------------|--------------------------------------------|
| CNAME       | custom.example.com | broker.endpoints.${PROJECT_ID?}.cloud.goog |

Allow up to 24 hours for the propagation of the created CNAME record, this process normally takes a few minutes though.

### Step 2: Create/Update the Secret Manager Secrets

#### Automated pipeline to create the secrets

Declare variables needed for the automated pipeline where:

- `_REGION`: cluster region
- `_CUSTOM_DOMAIN`: this variable is used to especify the custom domain for the App Launcher Portal.
- `_LB_DOMAINS`: is the list of additional domains to add to the managed certificate and configure in the cluster Load Balancer.

```bash
export _REGION=REPLACE_WITH_VALID_REGION
export _CUSTOM_DOMAIN="custom.example.com"
export _LB_DOMAINS="custom.example.com,another.example.com"
```

Execute pipeline

```bash
gcloud builds submit --project ${PROJECT_ID?} --substitutions=^--^_ACTION=apply--_REGION=${_REGION}--_CUSTOM_DOMAIN=${_CUSTOM_DOMAIN}--_LB_DOMAINS=${_LB_DOMAINS}
```

#### Create secrets manually

##### Update the project load balancer to use the DNS record and provision a Managed SSL Certificate.

Create or update the broker-tfvars-lbdomains secret with the following content:
additional_ssl_certificate_domains = [
    "${CUSTOM_DOMAIN}"
]

From the Selkies core repo, `setup/infra` subdirectory, run cloud build to preview then apply the domain change.

```bash
cd PATH_TO_YOUR_SELKIES_REPO_DIR
cd setup/infra
gcloud builds submit --project ${PROJECT_ID?} --substitutions=_ACTION=plan
gcloud builds submit --project ${PROJECT_ID?} --substitutions=_ACTION=apply
```

Allow some time for the SSL certificate to be provisioned, this may take up to 24 hours after the CNAME is pointed to the Default App Launcher domain. In most cases, propagation of the records and provisioning of the SSL certificate will happen within a few hours, depending on the domain provider.

##### Create broker-custom-domain secret

Custom domain secret  broker-custom-domain, this information is pulled during the manifest deployment step to configure the pod-broker with the configured domain.

```bash
gcloud secrets create  broker-custom-domain --replication-policy=automatic --data-file - <<EOF
${CUSTOM_DOMAIN}?
EOF
```

From the selkies repo, re-deploy the manifests from the selkies repo, `setup/manifests` directory to roll out the custom domain change.

##### Update the broker-logout-url secret

To properly redirect the browser to the correct url, the `secret broker-logout-url` has to be updated with the custom domain.

```bash
gcloud secrets versions add broker-logout-url --data-file=-
<<EOF
"https://${CUSTOM_DOMAIN}?gcp-iap-mode=GCIP_SIGNOUT"
EOF
```

### Step 3: Apply infra changes

From the Selkies core repo, `setup/infra` subdirectory, run cloud build to apply the domain change.

```bash
cd PATH_TO_YOUR_SELKIES_REPO_DIR
cd setup/infra
gcloud builds submit --project ${PROJECT_ID?} --substitutions=_ACTION=apply
```

Allow some time for the SSL certificate to be provisioned, this may take up to 24 hours after the CNAME is pointed to the Default App Launcher domain. In most cases, propagation of the records and provisioning of the SSL certificate will happen within a few hours, depending on the domain provider.

### Step 4: Re-deploy manifests

From the selkies repo, re-deploy the manifests from the selkies repo, `setup/manifests` directory to roll out the previusly configured changes.

```bash
cd PATH_TO_YOUR_SELKIES_REPO_DIR
cd setup/manifests
gcloud builds submit --project ${PROJECT_ID?}
```

### Step 5: Reinstall PWAs (Optional)

If any PWAs were installed, will need to be re-installed after being launched from the new URL.