### PR TITLE
1.22 upgrade

### DIFF
--- a/code-server/bundle-manifests/resource-code-virtual-service.yaml.tmpl
+++ b/code-server/bundle-manifests/resource-code-virtual-service.yaml.tmpl
@@ -18,7 +18,7 @@
 # ServiceEntry for web-preview URLs.
 # Required to do route based destinations and set-cookie redirect.
 ###
-apiVersion: networking.istio.io/v1alpha3
+apiVersion: networking.istio.io/v1beta1
 kind: ServiceEntry
 metadata:
   name: {{.ServiceName}}-web-preview
@@ -35,7 +35,7 @@ spec:
     protocol: HTTP
   resolution: DNS
 ---
-apiVersion: networking.istio.io/v1alpha3
+apiVersion: networking.istio.io/v1beta1
 kind: VirtualService
 metadata:
   name: {{.ServiceName}}

--- a/code-server/code-gateway.yaml
+++ b/code-server/code-gateway.yaml
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-apiVersion: networking.istio.io/v1alpha3
+apiVersion: networking.istio.io/v1beta1
 kind: Gateway
 metadata:
   name: code-gateway

--- a/external-auth/cloudbuild.yaml
+++ b/external-auth/cloudbuild.yaml
@@ -23,25 +23,27 @@ steps:
   ###
   # Deploy manifests to cluster.
   ###
-  - name: "gcr.io/cloud-builders/kubectl"
+  - name: "gcr.io/google.com/cloudsdktool/cloud-sdk"
     id: deploy-manifests
     entrypoint: "bash"
     args:
       - "-exc"
       - |
+        gcloud container clusters get-credentials $${CLOUDSDK_CONTAINER_CLUSTER} --region=$${CLOUDSDK_COMPUTE_REGION}
+
         kubectl kustomize manifests/ | \
           sed 's/$${PROJECT_ID}/'${PROJECT_ID}'/g' | \
-          /builder/kubectl.bash apply -f -
+          kubectl apply -f -
         
         # Apply the policy
         [[ ! -f ${_POLICY} ]] && "ERROR: Policy file not found: ${_POLICY}" && exit 1
         kubectl -n opa create configmap selkies-opa-policy \
           --from-file policy.rego=${_POLICY} --dry-run -o yaml | \
           kubectl label -f- --dry-run -o yaml --local openpolicyagent.org/policy=rego | \
-          /builder/kubectl.bash apply -f -
+          kubectl apply -f -
 
         # Get policy status
-        STATUS=$(/builder/kubectl.bash get cm -n opa selkies-opa-policy -o jsonpath='{.metadata.annotations.openpolicyagent\.org/policy-status}')
+        STATUS=$(kubectl get cm -n opa selkies-opa-policy -o jsonpath='{.metadata.annotations.openpolicyagent\.org/policy-status}')
         STATUS_OK='{"status":"ok"}'
         [[ ! $${STATUS} == $${STATUS_OK} ]] && echo "ERROR: failed to apply policy" && exit 1
         echo "Policy applied"

--- a/external-auth/manifests/selkies-opa.yaml
+++ b/external-auth/manifests/selkies-opa.yaml
@@ -185,10 +185,6 @@ spec:
     - namespaceSelector: 
         matchLabels:
           install.operator.istio.io/owner-kind: IstioControlPlane
-  egress: 
-  - to: 
-    - namespaceSelector: {}
   podSelector: {}
   policyTypes:
   - Ingress
-  - Egress

--- a/external-auth/manifests/selkies-opa.yaml
+++ b/external-auth/manifests/selkies-opa.yaml
@@ -19,9 +19,12 @@
 apiVersion: networking.istio.io/v1alpha3
 kind: EnvoyFilter
 metadata:
-  namespace: istio-system
   name: ext-authz
+  namespace: istio-system
 spec:
+  workloadSelector:
+    labels:
+      istio: ingressgateway
   configPatches:
     - applyTo: HTTP_FILTER
       match:
@@ -33,21 +36,17 @@ spec:
               subFilter:
                 name: "envoy.filters.http.router"
       patch:
-        operation: INSERT_FIRST
+        operation: INSERT_BEFORE
         value:
           name: envoy.ext_authz
           typed_config:
-            '@type': type.googleapis.com/envoy.config.filter.http.ext_authz.v2.ExtAuthz
+            '@type': type.googleapis.com/envoy.extensions.filters.http.ext_authz.v3.ExtAuthz
+            transport_api_version: V3
             status_on_error:
               code: ServiceUnavailable
-            
-            # Request body can break if binary data is sent, wait for newer Envoy proxy with fix before enabling.
-            # Until then, only header based auth is possible.
-            #    GH Issue: https://github.com/envoyproxy/envoy/issues/9822
-            #with_request_body:
-            #  max_request_bytes: 8192
-            #  allow_partial_message: true
-            
+            # with_request_body:
+            #   max_request_bytes: 8192
+            #   allow_partial_message: true
             grpc_service:
               # NOTE(tsandall): when this was tested with the envoy_grpc client the gRPC
               # server was receiving check requests over HTTP 1.1. The gRPC server in
@@ -57,7 +56,6 @@ spec:
               google_grpc:
                 target_uri: opa.opa.svc.cluster.local:9191
                 stat_prefix: "ext_authz"
-              timeout: 5s
 ---
 ###
 # Configuration for opa-istio container to enable OPA envoy plugin.
@@ -65,8 +63,8 @@ spec:
 apiVersion: v1
 kind: ConfigMap
 metadata:
-  namespace: opa
   name: opa-istio-config
+  namespace: opa
 data:
   config.yaml: |
     plugins:
@@ -128,7 +126,7 @@ spec:
   selector:
     app: opa
   ports:
-    - name: http-opa-istio
+    - name: http2-opa-istio
       port: 9191
       targetPort: 9191
 ---
@@ -155,11 +153,12 @@ spec:
           defaultMode: 420
       containers:
       - name: opa
-        image: openpolicyagent/opa:0.28.0-istio
+        image: openpolicyagent/opa:0.43.0-istio
         args:
         - "run"
         - "--server"
         - "--config-file=/config/config.yaml"
+        - "--log-level=debug"
         - "--addr=localhost:8181"
         - "--diagnostic-addr=0.0.0.0:8282"
         ports:
@@ -172,3 +171,24 @@ spec:
         image: openpolicyagent/kube-mgmt:0.12.1
         args:
           - --enable-data
+---
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  labels:
+    app.kubernetes.io/name: broker
+  name: allow-istio
+  namespace: opa
+spec:
+  ingress:
+  - from:
+    - namespaceSelector: 
+        matchLabels:
+          install.operator.istio.io/owner-kind: IstioControlPlane
+  egress: 
+  - to: 
+    - namespaceSelector: {}
+  podSelector: {}
+  policyTypes:
+  - Ingress
+  - Egress

--- a/external-auth/manifests/selkies-opa.yaml
+++ b/external-auth/manifests/selkies-opa.yaml
@@ -29,15 +29,15 @@ spec:
         listener:
           filterChain:
             filter:
-              name: "envoy.http_connection_manager"
+              name: "envoy.filters.network.http_connection_manager"
               subFilter:
-                name: "envoy.router"
+                name: "envoy.filters.http.router"
       patch:
-        operation: INSERT_BEFORE
+        operation: INSERT_FIRST
         value:
           name: envoy.ext_authz
           typed_config:
-            "@type": "type.googleapis.com/envoy.config.filter.http.ext_authz.v2.ExtAuthz"
+            '@type': type.googleapis.com/envoy.config.filter.http.ext_authz.v2.ExtAuthz
             status_on_error:
               code: ServiceUnavailable
             

--- a/monitoring/manifests/monitoring-gateway.yaml
+++ b/monitoring/manifests/monitoring-gateway.yaml
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-apiVersion: networking.istio.io/v1alpha3
+apiVersion: networking.istio.io/v1beta1
 kind: Gateway
 metadata:
   name: monitoring-gateway

--- a/monitoring/manifests/monitoring-virtualservice.yaml
+++ b/monitoring/manifests/monitoring-virtualservice.yaml
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-apiVersion: networking.istio.io/v1alpha3
+apiVersion: networking.istio.io/v1beta1
 kind: VirtualService
 metadata:
   name: monitoring

--- a/vdi-vm/manifests/bundle-manifests/resource-vdi-vm-controller.yaml.tmpl
+++ b/vdi-vm/manifests/bundle-manifests/resource-vdi-vm-controller.yaml.tmpl
@@ -61,7 +61,7 @@ metadata:
     iam.gke.io/gcp-service-account: vdi-vm-controller@{{.ProjectID}}.iam.gserviceaccount.com
 ---
 kind: RoleBinding
-apiVersion: rbac.authorization.k8s.io/v1beta1
+apiVersion: rbac.authorization.k8s.io/v1
 metadata:
   name: vm-controller
   labels:
@@ -76,7 +76,7 @@ roleRef:
   apiGroup: rbac.authorization.k8s.io
 ---
 kind: Role
-apiVersion: rbac.authorization.k8s.io/v1beta1
+apiVersion: rbac.authorization.k8s.io/v1
 metadata:
   name: vm-controller
   namespace: vm-controller-system

--- a/vdi-vm/manifests/bundle-manifests/resource-vdi-vm-virtual-service-linux.yaml.tmpl
+++ b/vdi-vm/manifests/bundle-manifests/resource-vdi-vm-virtual-service-linux.yaml.tmpl
@@ -14,7 +14,7 @@
 
 {{- if eq .AppParams.instanceOS "linux"}}
 
-apiVersion: networking.istio.io/v1alpha3
+apiVersion: networking.istio.io/v1beta1
 kind: VirtualService
 metadata:
   name: {{.ServiceName}}

--- a/vdi-vm/manifests/bundle-manifests/resource-vdi-vm-virtual-service-windows.yaml.tmpl
+++ b/vdi-vm/manifests/bundle-manifests/resource-vdi-vm-virtual-service-windows.yaml.tmpl
@@ -34,7 +34,7 @@
   {{- $instancePort = 5900 }}
 {{- end}}
 
-apiVersion: networking.istio.io/v1alpha3
+apiVersion: networking.istio.io/v1beta1
 kind: VirtualService
 metadata:
   name: {{.ServiceName}}


### PR DESCRIPTION
- `networking.istio.io/v1alpha3` to  `networking.istio.io/v1beta1`
- `Ext-authz` EnvoyFilter compatible with V3
- `rbac.authorization.k8s.io/v1beta1` to `rbac.authorization.k8s.io/v1`